### PR TITLE
Remove redundant assignment to variable ret

### DIFF
--- a/src/safe_str.c
+++ b/src/safe_str.c
@@ -168,7 +168,6 @@ int safe_strncmp(const char *const str1, const char *const str2, size_t maxlen)
 
 	if (str1 && str2 && (maxlen != 0))
 	{
-		ret = 1;
 		size_t idx = 0;
 
 		size_t str1size = safe_strnlen(str1, maxlen);


### PR DESCRIPTION
clang scan-build detected a redundant assignment to a variable
that can be removed:

safe_str.c:171:3: warning: Value stored to 'ret' is never read
                ret = 1;

Fix this by removing the assignment

Signed-off-by: Colin Ian King <colin.king@canonical.com>